### PR TITLE
initiate localrepo, branch, etc

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -40,14 +40,14 @@ class GitCommittersPlugin(BasePlugin):
             self.git_enabled = True
             LOG.info("git-committers plugin ENABLED")
             self.auth_header = {'Authorization': 'token ' + self.config['token'] }
-            if self.config['enterprise_hostname'] and self.config['enterprise_hostname'] != '':
-                self.apiendpoint = "https://" + self.config['enterprise_hostname'] + "/api/graphql"
-            else:
-                self.apiendpoint = "https://api.github.com/graphql"
-            self.localrepo = Repo(".")
-            self.branch = self.config['branch']
         else:
-            LOG.warning("git-committers plugin DISABLED: no git token provided")
+            LOG.warning("no git token provided")
+        if self.config['enterprise_hostname'] and self.config['enterprise_hostname'] != '':
+            self.apiendpoint = "https://" + self.config['enterprise_hostname'] + "/api/graphql"
+        else:
+            self.apiendpoint = "https://api.github.com/graphql"
+        self.localrepo = Repo(".")
+        self.branch = self.config['branch']
         return config
 
     def get_gituser_info(self, email, query):


### PR DESCRIPTION
Expected behavior when token is not provided is to produce warning, not to throw error. But at the moment trying to do so leads to

```
ERROR    -  Error building page 'index.md': 'GitCommittersPlugin' object has no attribute 'localrepo'
Traceback (most recent call last):
  File "/home/adamant/.local/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/__main__.py", line 181, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 63, in serve
    config = builder()
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 58, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/commands/build.py", line 314, in build
    _build_page(file.page, config, doc_files, nav, env, dirty)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/commands/build.py", line 212, in _build_page
    context = config['plugins'].run_event(
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs/plugins.py", line 102, in run_event
    result = method(item, **kwargs)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs_git_committers_plugin_2/plugin.py", line 145, in on_page_context
    authors, last_commit_date = self.get_git_info(git_path)
  File "/home/adamant/.local/lib/python3.10/site-packages/mkdocs_git_committers_plugin_2/plugin.py", line 82, in get_git_info
    for c in Commit.iter_items(self.localrepo, self.localrepo.head, path):
AttributeError: 'GitCommittersPlugin' object has no attribute 'localrepo'
```

By the way, since this impl is optimized to have lower amount of API calls, maybe the plugin should _not_ be disabled when the token is not provided?