### PR TITLE
Fix #9: remove image size from avatar attribute

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -67,7 +67,7 @@ class GitCommittersPlugin(BasePlugin):
                         return {'login':info['login'], \
                                 'name':info['name'], \
                                 'url':info['url'], \
-                                'avatar':info['url']+".png?size=24" }
+                                'avatar':info['url']+".png" }
                     else:
                         return None
                 else:


### PR DESCRIPTION
Remove image size from avatar attribute and let it at the initiative of the theme / plugin.