### PR TITLE
Fix #7: GitHub login is attempted before name

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -106,18 +106,18 @@ class GitCommittersPlugin(BasePlugin):
                     LOG.debug("      Found!")
                     author_id = c.author.email
                 else:
-                    # If not found, search by name
-                    LOG.debug("   User not found by email, search by name: " + c.author.name)
+                    # If not found, search by name, expecting it to be GitHub user name
+                    LOG.debug("   User not found yet, trying with GitHub username: " + c.author.name)
                     info = self.get_gituser_info( c.author.name, \
-                        { 'query': '{ search(type: USER, query: "in:name ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
+                        { 'query': '{ search(type: USER, query: "in:user ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
                     if info:
                         LOG.debug("      Found!")
                         author_id = c.author.name
                     else:
-                        # If not found, search by name, expecting it to be GitHub user name
-                        LOG.debug("   User not found yet, trying with GitHub username: " + c.author.name)
+                        # If not found, search by name
+                        LOG.debug("   User not found by email, search by name: " + c.author.name)
                         info = self.get_gituser_info( c.author.name, \
-                            { 'query': '{ search(type: USER, query: "in:user ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
+                            { 'query': '{ search(type: USER, query: "in:name ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
                         if info:
                             LOG.debug("      Found!")
                             author_id = c.author.name

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-git-committers-plugin-2',
-    version='0.4.3',
+    version='0.4.4',
     description='An MkDocs plugin to create a list of contributors on the page',
     long_description='The git-committers plugin will seed the template context with a list of github committers and other useful GIT info such as last modified date',
     keywords='mkdocs pdf github',


### PR DESCRIPTION
Reversing the order by which match is attempted. Now tries to first match by GitHub login, then by GitHub name.

![image](https://user-images.githubusercontent.com/5385290/187017687-334b4dd6-6755-4322-a729-d9f519f9da8b.png)
