### PR TITLE
Complete rewrite fetching contributors directly from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ I had to create this fork so that it could be uploaded and distributed through P
 
 This "v2" differs from the original by:
 
-* Use local git repo information to go through commits. In my test repos, I went from 200 API calls down to 10 (for a repository with 10 unique authors)
-* Fetch GitHub info only for authors
-* Fetch GitHub info for authors not fetched before
+* Fetch contributors directly from GitHub
+* Eliminate the need to match git commit logs with entries in GitHub, and thus GitHub API calls
+* No more risk of matching the incorrect contributor as the information comes directly from GitHub
 * last_commit_date is now populated with local git info
-* avatar is populated with gravatar info if there is no git token
-* Save all author information in a cache file to speed up following builds
+* No need for GitHub personal access token, as there are no more GitHub GraphQL API calls
 
-All of the above massively improve performances and reduce the chances to hit GitHub API rate limits.
+All of the above massively improves accuracy and performances.
 
 Note: the plugin configuration in `mkdocs.yml` still uses the original `git-committers` sections.
 
@@ -26,11 +25,14 @@ Install the plugin using pip:
 `pip install mkdocs-git-committers-plugin-2`
 
 Activate the plugin in `mkdocs.yml`:
+
 ```yaml
 plugins:
-  - search
-  - git-committers
+  - git-committers:
+      repository: organization/repository
+      branch: main
 ```
+
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
@@ -38,26 +40,13 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 
 ## Config
 
-* `enterprise_hostname` - The enterprise hostname of your github account (Github Enterprise customers only).
-* `repository` - The name of the repository, e.g. 'ojacques/mkdocs-git-committers-plugin-2'
-* `branch` - The name of the branch to pull commits from, e.g. 'master' (default)
-* `token` - A github Personal Access Token to avoid github rate limits. The token does not need any scope: uncheck everything when creating the GitHub Token at https://github.com/settings/tokens/new
-* `cache_dir` - The path of where to store the authors cache file, used to speed up documentation builds. Defaults to `.cache/plugin/git-committers/`. The cache file will be named `authors.json` in that directory
 * `enabled` - Disables plugin if set to `False` for e.g. local builds (default: `True`)
-
-Tip: You can specify the GitHub token via an environment variable in the following way:
-
-```yaml
-plugins:
-  - git-committers:
-      repository: johndoe/my-docs
-      branch: master
-      token: !ENV ["MKDOCS_GIT_COMMITTERS_APIKEY"]
-```
+* `repository` - The name of the repository, e.g. 'ojacques/mkdocs-git-committers-plugin-2'
+* `branch` - The name of the branch to get contributors from. Example: 'master' (default)
+* `enterprise_hostname` - For GitHub enterprise: the enterprise hostname.
+* `docs_path` - the path to the documentation folder. Defaults to `docs`.
 
 If the token is not set in `mkdocs.yml` it will be read from the `MKDOCS_GIT_COMMITTERS_APIKEY` environment variable.
-
-**If no token is present, the plugin will determine information with local git repository information only.**
 
 ## Usage
 
@@ -82,11 +71,7 @@ last updated.
 
 #### Avatar
 
-If the GitHub token is configured, a GitHub API request is made to retrieve the
-avatar from GitHub. If not, the avatar attribute is populated with gravatar
-identicon with an MD5 hash on the email address. If the author has configured
-gravatar for this email address, the avatar will show properly, otherwise a
-random but fixed gravatar identicon is generated.
+The avatar of the contributors is provided by GitHub. It uses maximal resolution.
 
 #### Template Code
 
@@ -161,3 +146,4 @@ Thank you to the following contributors:
 * Byrne Reese - original author, maintainer
 * Nathan Hernandez
 * Chris Northwood
+* Martin Donath

--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -11,9 +11,11 @@ from mkdocs.plugins import BasePlugin
 
 from git import Repo, Commit
 import requests, json
+from requests.exceptions import HTTPError
 import time
 import hashlib
 import re
+from bs4 import BeautifulSoup as bs
 
 LOG = logging.getLogger("mkdocs.plugins." + __name__)
 
@@ -24,9 +26,7 @@ class GitCommittersPlugin(BasePlugin):
         ('repository', config_options.Type(str, default='')),
         ('branch', config_options.Type(str, default='master')),
         ('docs_path', config_options.Type(str, default='docs/')),
-        ('token', config_options.Type(str, default='')),
         ('enabled', config_options.Type(bool, default=True)),
-        ('cache_dir', config_options.Type(str, default='.cache/plugin/git-committers')),
     )
 
     def __init__(self):
@@ -42,109 +42,52 @@ class GitCommittersPlugin(BasePlugin):
             return config
 
         LOG.info("git-committers plugin ENABLED")
-        if not self.config['token'] and 'MKDOCS_GIT_COMMITTERS_APIKEY' in os.environ:
-            self.config['token'] = os.environ['MKDOCS_GIT_COMMITTERS_APIKEY']
 
-        if self.config['token'] and self.config['token'] != '':
-            self.auth_header = {'Authorization': 'token ' + self.config['token'] }
-        else:
-            LOG.warning("no git token provided and MKDOCS_GIT_COMMITTERS_APIKEY environment variable is not defined")
+        if not self.config['repository']:
+            LOG.error("git-committers plugin: repository not specified")
+            return config
         if self.config['enterprise_hostname'] and self.config['enterprise_hostname'] != '':
-            self.apiendpoint = "https://" + self.config['enterprise_hostname'] + "/api/graphql"
+            self.githuburl = "https://" + self.config['enterprise_hostname'] + "/"
         else:
-            self.apiendpoint = "https://api.github.com/graphql"
+            self.githuburl = "https://github.com/"
         self.localrepo = Repo(".")
         self.branch = self.config['branch']
         return config
 
-    def get_gituser_info(self, email, query):
-        if not hasattr(self, 'auth_header'):
-            # No auth token provided: return now
-            return None
-        LOG.info("Get user info from GitHub for: " + email)
-        r = requests.post(url=self.apiendpoint, json=query, headers=self.auth_header)
-        res = r.json()
-        if r.status_code == 200:
-            if res.get('data'):
-                if res['data']['search']['edges']:
-                    info = res['data']['search']['edges'][0]['node']
-                    if info:
-                        return {'login':info['login'], \
-                                'name':info['name'], \
-                                'url':info['url'], \
-                                'avatar':info['url']+".png" }
-                    else:
-                        return None
-                else:
-                    return None
-            else:
-                LOG.warning("Error from GitHub GraphQL call: " + res['errors'][0]['message'])
-                return None
-        else:
-            return None
-
-    def get_git_info(self, path):
-        unique_authors = []
-        seen_authors = []
+    def list_contributors(self, path):
         last_commit_date = ""
-        LOG.debug("get_git_info for " + path)
         for c in Commit.iter_items(self.localrepo, self.localrepo.head, path):
-            author_id = ""
             if not last_commit_date:
                 # Use the last commit and get the date
                 last_commit_date = time.strftime("%Y-%m-%d", time.gmtime(c.authored_date))
-            c.author.email = c.author.email.lower()
-            # Clean up the email address
-            c.author.email = re.sub('\d*\+', '', c.author.email.replace("@users.noreply.github.com", ""))
-            if not (c.author.email in self.authors) and not (c.author.name in self.authors):
-                # Not in cache: let's ask GitHub
-                #self.authors[c.author.email] = {}
-                # First, search by email
-                info = self.get_gituser_info( c.author.email, \
-                    { 'query': '{ search(type: USER, query: "in:email ' + c.author.email + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
-                if info:
-                    LOG.debug("      Found!")
-                    author_id = c.author.email
-                else:
-                    # If not found, search by name, expecting it to be GitHub user name
-                    LOG.debug("   User not found yet, trying with GitHub username: " + c.author.name)
-                    info = self.get_gituser_info( c.author.name, \
-                        { 'query': '{ search(type: USER, query: "in:user ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
-                    if info:
-                        LOG.debug("      Found!")
-                        author_id = c.author.name
-                    else:
-                        # If not found, search by name
-                        LOG.debug("   User not found by email, search by name: " + c.author.name)
-                        info = self.get_gituser_info( c.author.name, \
-                            { 'query': '{ search(type: USER, query: "in:name ' + c.author.name + '", first: 1) { edges { node { ... on User { login name url } } } } }' })
-                        if info:
-                            LOG.debug("      Found!")
-                            author_id = c.author.name
-                        else:
-                            # If not found, use local git info only and gravatar avatar
-                            LOG.info("Get user info from local GIT info for: " + c.author.name)
-                            info = { 'login':c.author.name if c.author.name else '', \
-                                'name':c.author.name if c.author.name else c.author.email, \
-                                'url':'#', \
-                                'avatar':'https://www.gravatar.com/avatar/' + hashlib.md5(c.author.email.encode('utf-8')).hexdigest() + '?d=identicon' }
-                            author_id = c.author.name
-            else:
-                # Already in cache
-                if c.author.email in self.authors:
-                    info = self.authors[c.author.email]
-                    author_id = c.author.email
-                else:
-                    info = self.authors[c.author.name]
-                    author_id = c.author.name
-            if (author_id not in seen_authors):
-                LOG.debug("Adding " + author_id + " to unique authors for this page")
-                self.authors[author_id] = info
-                seen_authors.append(author_id)
-                unique_authors.append(self.authors[author_id])
 
-        LOG.debug("Contributors for page " + path + ": " + str(unique_authors))
-        return unique_authors, last_commit_date
+        url_contribs = self.githuburl + self.config['repository'] + "/contributors-list/" + self.config['branch'] + "/" + path
+        LOG.info("Fetching contributors for " + path)
+        LOG.debug("   from " + url_contribs)
+        try:
+            response = requests.get(url_contribs)
+            response.raise_for_status()
+        except HTTPError as http_err:
+            LOG.error(f'HTTP error occurred: {http_err}')
+        except Exception as err:
+            LOG.error(f'Other error occurred: {err}')
+        else:
+            html = response.text
+            # Parse the HTML
+            soup = bs(html, "lxml")
+            lis = soup.find_all('li')
+            authors=[]
+            for li in lis:
+                a_tags = li.find_all('a')
+                login = a_tags[0]['href'].replace("/", "")
+                url = self.githuburl + login
+                name = login
+                img_tags = li.find_all('img')
+                avatar = img_tags[0]['src']
+                avatar = re.sub(r'\?.*$', '', avatar)
+                authors.append({'login':login, 'name': name, 'url': url, 'avatar': avatar})
+
+        return authors, last_commit_date
 
     def on_page_context(self, context, page, config, nav):
         context['committers'] = []
@@ -152,7 +95,7 @@ class GitCommittersPlugin(BasePlugin):
             return context
         start = timer()
         git_path = self.config['docs_path'] + page.file.src_path
-        authors, last_commit_date = self.get_git_info(git_path)
+        authors, last_commit_date = self.list_contributors(git_path)
         if authors:
             context['committers'] = authors
         if last_commit_date:
@@ -161,18 +104,3 @@ class GitCommittersPlugin(BasePlugin):
         self.total_time += (end - start)
 
         return context
-
-    def on_post_build(self, config):
-        LOG.info("git-committers: saving authors cache file")
-        json_data = json.dumps(self.authors)
-        os.makedirs(self.config['cache_dir'], exist_ok=True)
-        f = open(self.config['cache_dir'] + "/authors.json", "w")
-        f.write(json_data)
-        f.close()
-
-    def on_pre_build(self, config):
-        if os.path.exists(self.config['cache_dir'] + "/authors.json"):
-            LOG.info("git-committers: loading authors cache file")
-            f = open(self.config['cache_dir'] + "/authors.json", "r")
-            self.authors = json.loads(f.read())
-            f.close()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-git-committers-plugin-2',
-    version='0.4.4',
+    version='1.0.0',
     description='An MkDocs plugin to create a list of contributors on the page',
     long_description='The git-committers plugin will seed the template context with a list of github committers and other useful GIT info such as last modified date',
     keywords='mkdocs pdf github',


### PR DESCRIPTION
I went ahead with the changes brainstormed in #14. This is a complete rewrite, with much simpler code now. The output is the same, but I still consider this a breaking change because of the completely new method. Hence version bump to 1.0.0.

- Fetch contributors from GitHub directly, leveraging the unsupported http endpoint `contributors-list` which lists all contributors for a given file and parse that.
- Fixes #7 as there is no more ambiguity possible with this new mechanism
- Eliminate the need for a GitHub personal access token
- Cache file introduced in 0.4.1 is removed. Which means there is no cache now, making this process linear with respects to how many documentation pages there are. To speed up the build, it is recommended to leverage the `enabled` boolean in plugin's `mkdocs.yml` and enable contributors for main/master branch builds only.

As I am leveraging an undocumented GitHub endpoint, there is a risk that this could break. Unfortunately, I could not find a way to this using a mix of GitHub GraphQL or REST API.

I tested this with the mkdocs-material and mkdocs-material insiders as well as few other repositories of mine. Works nicely. 