### PR TITLE
Fix #27: Allow Excluding Files/Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 - `enterprise_hostname` - For GitHub enterprise: the enterprise hostname.
 - `docs_path` - the path to the documentation folder. Defaults to `docs`.
 - `cache_dir` - The path which holds the authors cache file to speed up documentation builds. Defaults to `.cache/plugin/git-committers/`. The cache file is named `page-authors.json.json`.
+- `exclude` - Specify a list of page source paths (one per line) that should not have author(s) or last commit date included (excluded from processing by this plugin). Default is empty. [Example Usage](https://timvink.github.io/mkdocs-git-authors-plugin/options.html#exclude).
 
 ## Usage
 

--- a/mkdocs_git_committers_plugin_2/exclude.py
+++ b/mkdocs_git_committers_plugin_2/exclude.py
@@ -1,0 +1,43 @@
+"""
+Module to assist exclude certain files being processed by plugin.
+Inspired by https://github.com/apenwarr/mkdocs-exclude
+"""
+import os
+import fnmatch
+from typing import List
+
+
+def exclude(src_path: str, globs: List[str]) -> bool:
+    """
+    Determine if a src_path should be excluded.
+    Supports globs (e.g. folder/* or *.md).
+    Credits: code adapted from
+    https://github.com/timvink/mkdocs-git-authors-plugin/blob/master/mkdocs_git_authors_plugin/exclude.py
+    Args:
+        src_path (src): Path of file
+        globs (list): list of globs
+    Returns:
+        (bool): whether src_path should be excluded
+    """
+    assert isinstance(src_path, str)
+    assert isinstance(globs, list)
+
+    for g in globs:
+        if fnmatch.fnmatchcase(src_path, g):
+            return True
+
+        # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
+        # To make the same globs/regexes match filenames on Windows and
+        # other OSes, let's try matching against converted filenames.
+        # On the other hand, Unix actually allows filenames to contain
+        # literal \\ characters (although it is rare), so we won't
+        # always convert them.  We only convert if os.sep reports
+        # something unusual.  Conversely, some future mkdocs might
+        # report Windows filenames using / separators regardless of
+        # os.sep, so we *always* test with / above.
+        if os.sep != "/":
+            src_path_fix = src_path.replace(os.sep, "/")
+            if fnmatch.fnmatchcase(src_path_fix, g):
+                return True
+
+    return False


### PR DESCRIPTION
This is very useful for excluding this plugin on the home page or other pages in several use cases. Have adapted most of the code from https://github.com/timvink/mkdocs-git-authors-plugin.