### PR TITLE
Fix #38, #36, #30, #24 - now use GraphQL to fetch authors information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # mkdocs-git-committers-plugin-2
 
-This is a plugin which is a fork from the original [`mkdocs-git-committers-plugin`](https://github.com/byrnereese/mkdocs-git-committers-plugin) by @byrnereese.
+MkDocs plugin for displaying a list of committers associated with a file in
+mkdocs. The plugin uses [GitHub's GraphQL
+API](https://docs.github.com/en/graphql) to fetch the list of contributors for
+each page.
 
-MkDocs plugin for displaying a list of committers associated with a file in mkdocs.
+Other MkDocs plugins that use information to fetch authors:
+
+- [`mkdocs-git-authors-plugin`](https://github.com/timvink/mkdocs-git-authors-plugin) for displaying user names a number of lines contributed (uses local Git information)
+- [`mkdocs-git-committers-plugin`](https://github.com/byrnereese/mkdocs-git-committers-plugin) display contributors for a page (uses local Git information, completed with REST GitHub API v3)
+
+## History
+
+This is a fork from the original [`mkdocs-git-committers-plugin`](https://github.com/byrnereese/mkdocs-git-committers-plugin) by @byrnereese.
 
 I had to create this fork so that it could be uploaded and distributed through PyPi. The package has been renamed to `mkdocs-git-committers-plugin-2`.
 
@@ -12,11 +22,15 @@ This "v2" differs from the original by:
 - Eliminate the need to match git commit logs with entries in GitHub, and thus GitHub API calls
 - No more risk of matching the incorrect contributor as the information comes directly from GitHub
 - last_commit_date is now populated with local git info
-- No need for GitHub personal access token, as there are no more GitHub GraphQL API calls
+- Use a cache file to speed up following builds: authors are fetched from GitHub for a page only if that page has changed since the last build
 
-All of the above massively improves accuracy and performances.
+All of the above improves accuracy and performances.
 
 Note: the plugin configuration in `mkdocs.yml` still uses the original `git-committers` sections.
+
+## material for mkdocs theme
+
+This plugin is integrated in the [material for mkdocs](https://squidfunk.github.io/mkdocs-material/) theme by [Martin Donath](https://github.com/squidfunk).
 
 ## Limitations
 
@@ -37,7 +51,12 @@ plugins:
   - git-committers:
       repository: organization/repository
       branch: main
+      token: !ENV ["MKDOCS_GIT_COMMITTERS_APIKEY"]
 ```
+
+If the token is not set in `mkdocs.yml` it will be read from the `MKDOCS_GIT_COMMITTERS_APIKEY` environment variable.
+
+**Change in 2.0.0: if no token is present, the plugin will NOT add provide git committers.**
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
@@ -48,6 +67,7 @@ More information about plugins in the [MkDocs documentation][mkdocs-plugins].
 - `enabled` - Disables plugin if set to `False` for e.g. local builds (default: `True`)
 - `repository` - The name of the repository, e.g. 'ojacques/mkdocs-git-committers-plugin-2'
 - `branch` - The name of the branch to get contributors from. Example: 'master' (default)
+- `token` - A github fine-grained token for GitHub GraphQL API calls (classic tokens work too). The token does not need any scope: uncheck everything when creating the GitHub Token at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new), unless you access private repositories.
 - `enterprise_hostname` - For GitHub enterprise: the enterprise hostname.
 - `docs_path` - the path to the documentation folder. Defaults to `docs`.
 - `cache_dir` - The path which holds the authors cache file to speed up documentation builds. Defaults to `.cache/plugin/git-committers/`. The cache file is named `page-authors.json.json`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-beautifulsoup4
-gitpython
-lxml>=4.9
 mkdocs>=1.0.3
 requests

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def load_requirements(requirements_files: Union[Path, list[Path]]) -> list:
 
 setup(
     name='mkdocs-git-committers-plugin-2',
-    version='1.2.0',
+    version='2.0.0',
     description='An MkDocs plugin to create a list of contributors on the page. The git-committers plugin will seed the template context with a list of github committers and other useful GIT info such as last modified date',
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
BREAKING change! You need to setup a GitHub personal access token for the plugin to work (see `README.md`).

- Remove the use of undocumented `contributors-list` URI from GitHub, and move to GraphQL to query contributors
- Fix #36: beautifulsoup is no more required, the plugin only uses `requests`
- Fix #24, #30: plugin now supports private repositories if the GitHub token has access to it
