### PR TITLE
Fix exclude option ignoring exclusions

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -178,12 +178,11 @@ class GitCommittersPlugin(BasePlugin):
         return authors, last_commit_date
 
     def on_page_context(self, context, page, config, nav):
-        if exclude(page.file.src_path, self.excluded_pages):
-            LOG.warning("git-committers: " + page.file.src_path + " is excluded")
-            return context
-
         context['committers'] = []
         if not self.enabled:
+            return context
+        if exclude(page.file.src_path, self.excluded_pages):
+            LOG.warning("git-committers: " + page.file.src_path + " is excluded")
             return context
         start = timer()
         git_path = self.config['docs_path'] + page.file.src_path

--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -151,10 +151,6 @@ class GitCommittersPlugin(BasePlugin):
             return []
         
     def list_contributors(self, path):
-        if exclude(path.lstrip(self.config['docs_path']), self.excluded_pages):
-            LOG.warning("git-committers: " + path + " is excluded")
-            return None, None
-        
         last_commit_date = ""
         path = path.replace("\\", "/")
         for c in Commit.iter_items(self.localrepo, self.localrepo.head, path):
@@ -182,6 +178,10 @@ class GitCommittersPlugin(BasePlugin):
         return authors, last_commit_date
 
     def on_page_context(self, context, page, config, nav):
+        if exclude(page.file.src_path, self.excluded_pages):
+            LOG.warning("git-committers: " + page.file.src_path + " is excluded")
+            return context
+
         context['committers'] = []
         if not self.enabled:
             return context


### PR DESCRIPTION
It seems like the exclude option was not working properly and ignoring some exclusions that we've set in our project (https://github.com/HedgeDocs/HedgeDocs.github.io). However, moving this check to the `on_page_context` function seemed to fix our issue.

I assume the actual problem is the usage of `path.lstrip`, but doing the check in `on_page_context` allows us to skip over excluded files earlier as well, so I think it makes sense to do this change.