### PR TITLE
fix: search parent directories to find repository

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -76,7 +76,7 @@ class GitCommittersPlugin(BasePlugin):
                 LOG.error("git-committers plugin: GitLab API requires a token. Set it under 'token' mkdocs.yml config or MKDOCS_GIT_COMMITTERS_APIKEY environment variable.")
             else:
                 LOG.warning("git-committers plugin may require a GitHub token if you exceed the API rate limit or for private repositories. Set it under 'token' mkdocs.yml config or MKDOCS_GIT_COMMITTERS_APIKEY environment variable.")
-        self.localrepo = Repo(".")
+        self.localrepo = Repo(".", search_parent_directories=True)
         self.branch = self.config['branch']
         self.excluded_pages = self.config['exclude']
         return config


### PR DESCRIPTION
Fixes #41.

Allows for repositories where their documentation pipeline is not run from the root directory, e.g. a documentation repository where `mkdocs.yml` is at `docs/mkdocs.yml`, along with e.g. `docs/pyproject.toml`.

Particularly relevant for non-Python projects and monorepos.