### PR TITLE
Change excluded file log level to INFO

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -182,7 +182,7 @@ class GitCommittersPlugin(BasePlugin):
         if not self.enabled:
             return context
         if exclude(page.file.src_path, self.excluded_pages):
-            LOG.warning("git-committers: " + page.file.src_path + " is excluded")
+            LOG.info("git-committers: " + page.file.src_path + " is excluded")
             return context
         start = timer()
         git_path = self.config['docs_path'] + page.file.src_path


### PR DESCRIPTION
Changes the excluded file log level to INFO. This is required for compatibility with mkdocs strict mode.

See https://github.com/ojacques/mkdocs-git-committers-plugin-2/issues/52