### PR TITLE
fix: Added api_version to config

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -24,6 +24,7 @@ class GitCommittersPlugin(BasePlugin):
         ('gitlab_hostname', config_options.Type(str, default='')),
         ('repository', config_options.Type(str, default='')),           # For GitHub: owner/repo
         ('gitlab_repository', config_options.Type(int, default=0)),     # For GitLab: project_id
+        ('api_version', config_options.Type(str, default=None)),
         ('branch', config_options.Type(str, default='master')),
         ('docs_path', config_options.Type(str, default='docs/')),
         ('enabled', config_options.Type(bool, default=True)),


### PR DESCRIPTION
`mkdocs` build in strict mode (`-s`) fails if you pass in parameters that aren't explicitly listed out in the plugin config. `api_version` needs to be present in `self.config` for the url builder to work, so this just adds the value in, defaulting to None.