### PR TITLE
Show correct default value of docs_path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For private GitHub repositories, you only need to allow read-only access to `Con
   gitlab.com (self-hosted).
 - `api_version` - For GitHub and GitLab self-hosted, the API version part that needs to be appended to the URL. 
   Defaults to v4 for GitLab, and nothing for GitHub Enterprise (you may need `v3`).
-- `docs_path` - the path to the documentation folder. Defaults to `docs`.
+- `docs_path` - the path to the documentation folder. Defaults to `docs/`.
 - `cache_dir` - The path which holds the authors cache file to speed up
   documentation builds. Defaults to `.cache/plugin/git-committers/`. The cache
   file is named `page-authors.json`.


### PR DESCRIPTION
Leaving out the trailing slash breaks the generation process without any error. Took me a while to figure this out.