### PR TITLE
Fix KeyError: 'api_version' for self-hosted SCM

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -60,12 +60,12 @@ class GitCommittersPlugin(BasePlugin):
             LOG.error("git-committers plugin: repository not specified")
             return config
         if self.config['enterprise_hostname'] and self.config['enterprise_hostname'] != '':
-            if not self.config['api_version']:
+            if not self.config.get('api_version'):
                 self.githuburl = "https://" + self.config['enterprise_hostname'] + "/api"
             else:
                 self.githuburl = "https://" + self.config['enterprise_hostname'] + "/api/" + self.config['api_version']
         if self.config['gitlab_hostname'] and self.config['gitlab_hostname'] != '':
-            if not self.config['api_version']:
+            if not self.config.get('api_version'):
                 self.gitlaburl = "https://" + self.config['gitlab_hostname'] + "/api/v4"
             else:
                 self.gitlaburl = "https://" + self.config['gitlab_hostname'] + "/api/" + self.config['api_version']


### PR DESCRIPTION
This is a proposal for a fix in case this plugin is used for GitLab self-hosted or GitHub enterprise repositories.

Currently this in case GitLab self-hosted or GitHub enterprise repo is being used with the newest version of this plugin, it would return the following error:
```python
INFO    -  git-committers plugin ENABLED
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
  File "/usr/local/lib/python3.9/site-packages/mkdocs/commands/build.py", line 265, in build
    config = config.plugins.on_config(config)
  File "/usr/local/lib/python3.9/site-packages/mkdocs/plugins.py", line 587, in on_config
    return self.run_event('config', config)
  File "/usr/local/lib/python3.9/site-packages/mkdocs/plugins.py", line 566, in run_event
    result = method(item, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/mkdocs_git_committers_plugin_2/plugin.py", line 67, in on_config
    if not self.config['api_version']:
  File "/usr/local/lib/python3.9/collections/__init__.py", line 1058, in __getitem__
    raise KeyError(key)
KeyError: 'api_version'
```

This change proposes to change the dict key access to a safer version.