### PR TITLE
fix #72: UnboundLocalError user variable fix for github and gitlab

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -124,7 +124,7 @@ class GitCommittersPlugin(BasePlugin):
                             authors.append({'login': commit['committer']['login'],
                                             'name': commit['committer']['login'],
                                             'url': commit['committer']['html_url'],
-                                            'avatar': commit['committer']['avatar_url'] if commit['author']['avatar_url'] is not None else ''
+                                            'avatar': commit['committer']['avatar_url'] if commit['committer']['avatar_url'] is not None else ''
                                             })
                         if commit['commit'] and commit['commit']['message'] and '\nCo-authored-by:' in commit['commit']['message']:
                             github_coauthors_exist = True

--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -118,13 +118,13 @@ class GitCommittersPlugin(BasePlugin):
                             authors.append({'login': commit['author']['login'],
                                             'name': commit['author']['login'],
                                             'url': commit['author']['html_url'],
-                                            'avatar': commit['author']['avatar_url'] if user['avatar_url'] is not None else ''
+                                            'avatar': commit['author']['avatar_url'] if commit['author']['avatar_url'] is not None else ''
                                             })
                         if commit['committer'] and commit['committer']['login'] and commit['committer']['login'] not in [author['login'] for author in authors]:
                             authors.append({'login': commit['committer']['login'],
                                             'name': commit['committer']['login'],
                                             'url': commit['committer']['html_url'],
-                                            'avatar': commit['committer']['avatar_url'] if user['avatar_url'] is not None else ''
+                                            'avatar': commit['committer']['avatar_url'] if commit['author']['avatar_url'] is not None else ''
                                             })
                         if commit['commit'] and commit['commit']['message'] and '\nCo-authored-by:' in commit['commit']['message']:
                             github_coauthors_exist = True
@@ -138,7 +138,7 @@ class GitCommittersPlugin(BasePlugin):
                                     authors.append({'login': self.gitlabauthors_cache[commit['author_name']]['username'],
                                                     'name': commit['author_name'],
                                                     'url': self.gitlabauthors_cache[commit['author_name']]['web_url'],
-                                                    'avatar': self.gitlabauthors_cache[commit['author_name']]['avatar_url'] if user['avatar_url'] is not None else ''
+                                                    'avatar': self.gitlabauthors_cache[commit['author_name']]['avatar_url'] if self.gitlabauthors_cache[commit['author_name']]['avatar_url'] is not None else ''
                                                     })
                                 else:
                                     # Fetch author from GitLab API


### PR DESCRIPTION
Hello :wave:  I am contributor from roboflow/supervision project and Maintainer @LinasKo notice that we have issue in fetching avatars and I made fix for https://github.com/ojacques/mkdocs-git-committers-plugin-2/issues/72 for both gitlab and github based on api docs. 

Test case (we should be able to build docs without error)

```console
export GITHUB_TOKEN_ENV=github_pat_xxxxxx
rm -rf .cache/plugin/git-committers/
pip install git+http://github.com/onuralpszr/mkdocs-git-committers-plugin-2@fix/issue72
mkdocs build
```

Small wish: It would be nice to have hotfix pypi release so we can also have cleanly update our side instead of downgrade package as well. 

Thank you.

cc @ojacques
For test: cc @LinasKo
