### PR TITLE
Fix GitHub regressions in #69

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -118,13 +118,13 @@ class GitCommittersPlugin(BasePlugin):
                             authors.append({'login': commit['author']['login'],
                                             'name': commit['author']['login'],
                                             'url': commit['author']['html_url'],
-                                            'avatar': commit['author']['avatar_url'] if user['avatar_url'] is not None else ''
+                                            'avatar': commit['author']['avatar_url']
                                             })
                         if commit['committer'] and commit['committer']['login'] and commit['committer']['login'] not in [author['login'] for author in authors]:
                             authors.append({'login': commit['committer']['login'],
                                             'name': commit['committer']['login'],
                                             'url': commit['committer']['html_url'],
-                                            'avatar': commit['committer']['avatar_url'] if user['avatar_url'] is not None else ''
+                                            'avatar': commit['committer']['avatar_url']
                                             })
                         if commit['commit'] and commit['commit']['message'] and '\nCo-authored-by:' in commit['commit']['message']:
                             github_coauthors_exist = True
@@ -138,7 +138,7 @@ class GitCommittersPlugin(BasePlugin):
                                     authors.append({'login': self.gitlabauthors_cache[commit['author_name']]['username'],
                                                     'name': commit['author_name'],
                                                     'url': self.gitlabauthors_cache[commit['author_name']]['web_url'],
-                                                    'avatar': self.gitlabauthors_cache[commit['author_name']]['avatar_url'] if user['avatar_url'] is not None else ''
+                                                    'avatar': self.gitlabauthors_cache[commit['author_name']]['avatar_url']
                                                     })
                                 else:
                                     # Fetch author from GitLab API


### PR DESCRIPTION
Error message:

        'avatar': commit['author']['avatar_url'] if user['avatar_url'] is not None else ''
    UnboundLocalError: local variable 'user' referenced before assignment

Ref: https://github.com/ojacques/mkdocs-git-committers-plugin-2/pull/69