### PR TITLE
Support JWT for GitHub authentication.

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -80,7 +80,7 @@ class GitCommittersPlugin(BasePlugin):
             if self.config['gitlab_repository']:
                 self.auth_header = {'PRIVATE-TOKEN': self.config['token'] }
             else:
-                self.auth_header = {'Authorization': 'token ' + self.config['token'] }
+                self.auth_header = {'Authorization': 'Bearer ' + self.config['token'] }
         else:
             self.auth_header = None
             if self.config['gitlab_repository']:


### PR DESCRIPTION
Hello,

I'm not in any trouble, but GitHub supports JWT only when `Bearer` is specified in the `Authentication` header.
https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#about-authentication

I'm not sure that this change doesn't break the current behavior, but if you feel like it, could you please merge this PR?