### PR TITLE
support tilde ~ char in cache_dir

### DIFF
--- a/mkdocs_git_committers_plugin_2/plugin.py
+++ b/mkdocs_git_committers_plugin_2/plugin.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import pathlib
 from pprint import pprint
 from timeit import default_timer as timer
 from datetime import datetime, timedelta
@@ -91,6 +92,8 @@ class GitCommittersPlugin(BasePlugin):
         self.branch = self.config['branch']
         self.excluded_pages = self.config['exclude']
         self.exclude_committers = self.config['exclude_committers']
+        self.config['cache_dir'] = str(pathlib.Path(self.config['cache_dir']).expanduser())
+
         return config
 
     # Get unique contributors for a given path


### PR DESCRIPTION
`~/.cache` is a very common caching directory, but currently this plugin only supports it with an absolute path. This PR enables that you can also use the `~` tilde sign in `cache_dir`